### PR TITLE
Update deprecated versioning function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@
 *.gz
 *.whl
 .vscode/settings.json
+.vscode/launch.json

--- a/pyparcels/versioning/versioning_utils.py
+++ b/pyparcels/versioning/versioning_utils.py
@@ -42,6 +42,9 @@ def get_version(vms, owner_name, version_name):
 def create_version(vms, version_name=None):
     """Create a new branch version
 
+    OBSOLETE: The ArcGIS API for Python (2.0.0) returns the full `versionInfo` dict
+    including the fully qualified name. Use `vms.create(version_name)["versionInfo"]`
+    
     Args:
       vms (arcgis.features._version.VersionManager): VersionManager object 
       version_name (str): (Optional) name of the version to be created

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
 
     name='pyparcels',  # Required
 
-    version='1.0.0',  # Required
+    version='1.0.1',  # Required
 
     description='Helper functions for simplifying parcel fabric workflows with the ArcGIS Python API',  # Optional
 


### PR DESCRIPTION
Add deprecated note to create_version function. Version 2.0.0 of the ArcGIS Python API removed the need for this function.