### PR TITLE
Update create_version using versionInfo

### DIFF
--- a/pyparcels/versioning/versioning_utils.py
+++ b/pyparcels/versioning/versioning_utils.py
@@ -42,9 +42,6 @@ def get_version(vms, owner_name, version_name):
 def create_version(vms, version_name=None):
     """Create a new branch version
 
-    OBSOLETE: The ArcGIS API for Python (2.0.0) returns the full `versionInfo` dict
-    including the fully qualified name. Use `vms.create(version_name)["versionInfo"]`
-    
     Args:
       vms (arcgis.features._version.VersionManager): VersionManager object 
       version_name (str): (Optional) name of the version to be created
@@ -58,15 +55,7 @@ def create_version(vms, version_name=None):
             version_name = "api-{}".format(timestamp)
         else:
             version_name = f"{version_name}_{timestamp}"
-        vms.create(version_name)
-
-        # get the fully qualified version name string as 'owner.versionName'
-        _version = [
-            x for x in vms.all
-            if x.properties.versionName.lower() == "admin." + version_name
-        ]
-        fq_version_name = _version[0].properties.versionName
-        return fq_version_name
+        return vms.create(version_name)["versionInfo"]["versionName"]
     except Exception as ex:
         print(ex)
         return None

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup(
 
     name='pyparcels',  # Required
 
-    version='1.0.1',  # Required
+    version='1.1.0',  # Required
 
     description='Helper functions for simplifying parcel fabric workflows with the ArcGIS Python API',  # Optional
 


### PR DESCRIPTION
Forget the deprecation. Just use the new `versionInfo` dict returned by `vms.create` and bump the version up to 1.1.0